### PR TITLE
chore: add bin command name

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   "module": "./dist/index.mjs",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
-  "bin": "./bin/pack-up.js",
+  "bin": {
+    "pack-up": "./bin/pack-up.js"
+  },
   "files": [
     "bin",
     "dist"


### PR DESCRIPTION
### What does it do?

adds an explicit name for the pack-up command

### Why is it needed?

It's safer and it was having issues when in nested file references (a plugin with a file ref to a version of plugin-cli with a file ref to pack-up was not able to find the pack-up command)

### How to test it?

It should still work exactly as before


