### PR TITLE
fix: log levels

### DIFF
--- a/.changeset/red-frogs-cry.md
+++ b/.changeset/red-frogs-cry.md
@@ -1,0 +1,5 @@
+---
+'@strapi/pack-up': patch
+---
+
+Use correct log level for all errors

--- a/src/node/tasks/dts/diagnostic.ts
+++ b/src/node/tasks/dts/diagnostic.ts
@@ -8,35 +8,35 @@ const printDiagnostic = (
   diagnostic: ts.Diagnostic,
   { logger, cwd }: { logger: Logger; cwd: string }
 ) => {
+  let output = ts.flattenDiagnosticMessageText(diagnostic.messageText, ts.sys.newLine);
+
   if (diagnostic.file && diagnostic.start) {
     const { line, character } = ts.getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start);
     const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ts.sys.newLine);
 
     const file = path.relative(cwd, diagnostic.file.fileName);
 
-    const output = [
+    output = [
       `${chalk.cyan(file)}:${chalk.cyan(line + 1)}:${chalk.cyan(character + 1)} - `,
       `${chalk.gray(`TS${diagnostic.code}:`)} ${message}`,
     ].join('');
+  }
 
-    switch (diagnostic.category) {
-      case ts.DiagnosticCategory.Error:
-        logger.error(output);
-        break;
-      case ts.DiagnosticCategory.Warning:
-        logger.warn(output);
-        break;
-      case ts.DiagnosticCategory.Message:
-        logger.info(output);
-        break;
-      case ts.DiagnosticCategory.Suggestion:
-        logger.info(output);
-        break;
-      default:
-        break;
-    }
-  } else {
-    logger.info(ts.flattenDiagnosticMessageText(diagnostic.messageText, ts.sys.newLine));
+  switch (diagnostic.category) {
+    case ts.DiagnosticCategory.Error:
+      logger.error(output);
+      break;
+    case ts.DiagnosticCategory.Warning:
+      logger.warn(output);
+      break;
+    case ts.DiagnosticCategory.Message:
+      logger.info(output);
+      break;
+    case ts.DiagnosticCategory.Suggestion:
+      logger.info(output);
+      break;
+    default:
+      break;
   }
 };
 


### PR DESCRIPTION
### What does it do?

use the correct log level for errors that are not diagnostic.file && diagnostic.start

### Why is it needed?

errors were being logged with the wrong log levels

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
