### PR TITLE
fix: check for nullish prop instead of falsy

### DIFF
--- a/.changeset/smart-months-provide.md
+++ b/.changeset/smart-months-provide.md
@@ -1,0 +1,5 @@
+---
+'@strapi/pack-up': patch
+---
+
+Check for nullish build options and don't fallback for falsy values

--- a/src/node/core/config.ts
+++ b/src/node/core/config.ts
@@ -124,7 +124,7 @@ type ConfigProperty<T> = T | ConfigPropertyResolver<T>;
 
 /** @internal */
 export function resolveConfigProperty<T>(prop: ConfigProperty<T> | undefined, initialValue: T): T {
-  if (!prop) {
+  if (prop === undefined || prop === null) {
     return initialValue;
   }
 


### PR DESCRIPTION
### What does it do?

Fix the allowence of falsy (`false`) build options values.

### Why is it needed?

The build option `sourcemap: false` would not work, as it would fallback to it's initial value: `true`.

https://github.com/strapi/pack-up/blob/5e239796b21c2576939802e28b9022e77f19e1fe/src/node/tasks/vite/config.ts#L47-L48

Funny enough it would work for minify as the fallback value already was set to false 😉 

### Related PRs
#13 
