### PR TITLE
fix: remove commander build option fallbacks

### DIFF
--- a/.changeset/good-parrots-push.md
+++ b/.changeset/good-parrots-push.md
@@ -1,0 +1,5 @@
+---
+'@strapi/pack-up': patch
+---
+
+Fix build option fallback usage

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -4,8 +4,5 @@
   "initialVersions": {
     "@strapi/pack-up": "5.0.0"
   },
-  "changesets": [
-    "four-games-camp",
-    "red-frogs-cry"
-  ]
+  "changesets": ["four-games-camp", "red-frogs-cry"]
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,8 +17,8 @@ command('check').action(async (options) => {
 });
 
 command('build')
-  .option('--sourcemap', 'produce sourcemaps', true)
-  .option('--minify', 'minify the output', false)
+  .option('--sourcemap', 'produce sourcemaps') // Default true, as set in the vite config
+  .option('--minify', 'minify the output') // Default false, as set in the vite config
   .action(async (options) => {
     const { build } = await import('./commands/build');
 


### PR DESCRIPTION
### What does it do?

Fixes build option usage in `packup.config.js`

### Why is it needed?

The commander build options are merged with the option from `packup.config.js`, but as the commander options have a fallback value even if the option isn't set the option will overwrite the value from the config file. The fallback value for vite is also set in the `tasks/vite/config`.

### Related PRs
#12 

