### PR TITLE
Upgrade actions/download-artifact to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: corepack enable && pnpm --version
       - run: pnpm install
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Restore build output
         with:
           name: build-output


### PR DESCRIPTION
### What does it do?

Upgrade actions/download-artifact to v4

### Why is it needed?

Avoid having a high vulnerability, see https://github.com/advisories/GHSA-cxww-7g56-2vh6

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
