### PR TITLE
fix: use dynamic import to avoid vite warning

### DIFF
--- a/.changeset/green-bottles-sparkle.md
+++ b/.changeset/green-bottles-sparkle.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: use dynamic import to avoid vite warning

--- a/src/node/tasks/vite/config.ts
+++ b/src/node/tasks/vite/config.ts
@@ -2,7 +2,6 @@
 import react from '@vitejs/plugin-react-swc';
 import { builtinModules } from 'node:module';
 import path from 'path';
-import { mergeConfig } from 'vite';
 
 import { resolveConfigProperty } from '../../core/config';
 
@@ -134,7 +133,9 @@ const resolveViteConfig = async (ctx: BuildContext, task: ViteBaseTask) => {
     plugins: [...basePlugins, ...plugins],
   } satisfies InlineConfig;
 
-  return mergeConfig(config, ctx.config.unstable_viteConfig ?? {});
+  return import('vite').then(({ mergeConfig }) =>
+    mergeConfig(config, ctx.config.unstable_viteConfig ?? {})
+  );
 };
 
 export { resolveViteConfig };


### PR DESCRIPTION
### What does it do?

fix: use dynamic import to avoid vite warning