### PR TITLE
fix: add permissions to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
### What does it do?

adds write permissions 

### Why is it needed?

The automated release is failing because of a permission issue it seems

### How to test it?

- merge and see if the auto release will work
- either way it's better to have the permissions specified

