### PR TITLE
fix: allow strings without ending in json

### DIFF
--- a/.changeset/late-balloons-pay.md
+++ b/.changeset/late-balloons-pay.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: allow strings without ending in json

--- a/.changeset/late-balloons-pay.md
+++ b/.changeset/late-balloons-pay.md
@@ -1,5 +1,4 @@
 ---
-
 ---
 
 fix: allow strings without ending in json

--- a/src/node/core/exports.ts
+++ b/src/node/core/exports.ts
@@ -310,8 +310,8 @@ const parseExports = ({ extMap, pkg }: { extMap: ExtMap; pkg: PackageJson }) => 
 
           extraExports.push(extraExport);
         }
-      } else {
-        errors.push('package.json: exports must be an object');
+      } else if (!['string', 'object'].includes(typeof entry)) {
+        errors.push('package.json: exports must be an object or string');
       }
     });
   }

--- a/src/node/core/pkg.ts
+++ b/src/node/core/pkg.ts
@@ -115,10 +115,7 @@ const packageJsonSchema = yup.object({
                     })
                     .noUnknown(true);
                 } else {
-                  acc[key] = yup
-                    .string()
-                    .matches(/^\.\/.*\.json$/)
-                    .required();
+                  acc[key] = yup.string().required();
                 }
 
                 return acc;


### PR DESCRIPTION
### What does it do?

loosens the validation on export values

### Why is it needed?

to allow files other than .json to be used

### How to test it?

run pack-up against a project that has something like
```
exports: {
  "./myfile.css": "./myfile.css"
}
```

### Related issue(s)/PR(s)

https://github.com/strapi/sdk-plugin/issues/73